### PR TITLE
Fix preview and URL sync for input events

### DIFF
--- a/public_html/main.js
+++ b/public_html/main.js
@@ -47,7 +47,7 @@ if (typeof window !== 'undefined') {
             }, 300);
         };
 
-        ['change', 'keyup', 'paste', 'mouseup'].forEach(evt => {
+        ['change', 'keyup', 'paste', 'mouseup', 'input'].forEach(evt => {
             mathsEditor.addEventListener(evt, updateHandler);
         });
 

--- a/tests/editor-sync.test.js
+++ b/tests/editor-sync.test.js
@@ -1,0 +1,98 @@
+class FakeEventTarget {
+    constructor() {
+        this.listeners = new Map();
+    }
+
+    addEventListener(type, listener) {
+        const listeners = this.listeners.get(type) || [];
+        listeners.push(listener);
+        this.listeners.set(type, listeners);
+    }
+
+    dispatchEvent(event) {
+        for (const listener of this.listeners.get(event.type) || []) {
+            listener(event);
+        }
+    }
+}
+
+function createBrowserHarness() {
+    const mathsEditor = new FakeEventTarget();
+    mathsEditor.value = 'x';
+
+    const output = { textContent: '' };
+    const document = new FakeEventTarget();
+    document.createElement = () => ({
+        parentNode: { insertBefore: jest.fn() }
+    });
+    document.getElementsByTagName = () => [{
+        parentNode: { insertBefore: jest.fn() }
+    }];
+    document.getElementById = id => id === 'maths-editor' ? mathsEditor : null;
+    document.querySelector = selector => selector === '#math-output p' ? output : null;
+    document.querySelectorAll = () => [];
+
+    const originalGlobals = new Map();
+    for (const name of ['window', 'document', 'parent', 'location', 'ga', 'addEventListener']) {
+        originalGlobals.set(name, global[name]);
+    }
+
+    global.window = global;
+    global.document = document;
+    global.parent = { location: { hash: '' } };
+    global.location = { hash: '' };
+    global.ga = jest.fn();
+    global.addEventListener = jest.fn();
+
+    jest.resetModules();
+    require('../public_html/main.js');
+    document.dispatchEvent({ type: 'DOMContentLoaded' });
+
+    return {
+        mathsEditor,
+        output,
+        parent: global.parent,
+        restore() {
+            jest.resetModules();
+            for (const [name, value] of originalGlobals) {
+                if (value === undefined) {
+                    delete global[name];
+                } else {
+                    global[name] = value;
+                }
+            }
+        }
+    };
+}
+
+describe('editor synchronization', () => {
+    let activeHarness;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        if (activeHarness) {
+            activeHarness.restore();
+            activeHarness = null;
+        }
+        jest.useRealTimers();
+    });
+
+    it('updates the preview and URL hash for input events', () => {
+        activeHarness = createBrowserHarness();
+
+        activeHarness.mathsEditor.value = 'x+y';
+        activeHarness.mathsEditor.dispatchEvent({ type: 'input' });
+
+        jest.advanceTimersByTime(299);
+        expect(activeHarness.output.textContent).toBe('$$\\displaystyle{x}$$');
+        expect(activeHarness.parent.location.hash).toBe('');
+
+        jest.advanceTimersByTime(1);
+        expect(activeHarness.output.textContent).toBe('$$\\displaystyle{x+y}$$');
+        expect(activeHarness.parent.location.hash).toBe(encodeURIComponent('x+y'));
+    });
+
+});


### PR DESCRIPTION
## Summary

- Subscribe `#maths-editor` to the existing debounced synchronization handler for `input` events.
- Add a browser-event regression test that verifies both preview rendering and URL-fragment updates after an input-only edit.

Root cause: the shared handler was registered for `change`, `keyup`, `paste`, and `mouseup`, but not `input`, so drag/drop, IME commits, menu undo/redo, and similar edits left the preview and fragment stale.

Closes #6

## Validation

- `npx jest tests/editor-sync.test.js --runInBand`
- `npm test -- --runInBand --roots tests`
