### PR TITLE
Fix URL hash history and navigation sync

### DIFF
--- a/public_html/main.js
+++ b/public_html/main.js
@@ -29,20 +29,76 @@ if (typeof window !== 'undefined') {
 
     document.addEventListener("DOMContentLoaded", () => {
         const mathsEditor = document.getElementById("maths-editor");
+        const initialEditorValue = mathsEditor.value;
+
+        const getUrlTarget = () => {
+            try {
+                if (window.parent && window.parent.location) {
+                    return window.parent;
+                }
+            } catch (err) {
+                // Fall back to the current window when the parent is inaccessible.
+            }
+            return window;
+        };
+
+        const getEncodedHash = () => {
+            const urlTarget = getUrlTarget();
+
+            try {
+                if (urlTarget.location.hash) {
+                    return urlTarget.location.hash.substring(1);
+                }
+            } catch (err) {
+                // Fall back to the current window when the target hash is inaccessible.
+            }
+
+            try {
+                if (window.location.hash) {
+                    return window.location.hash.substring(1);
+                }
+            } catch (err) {
+                // Ignore inaccessible URL state.
+            }
+
+            return null;
+        };
 
         let debounceTimer;
+        const updateFromHash = () => {
+            clearTimeout(debounceTimer);
+            try {
+                const encodedHash = getEncodedHash();
+                const value = encodedHash === null ? initialEditorValue : decodeURIComponent(encodedHash);
+                mathsEditor.value = value;
+            } catch (err) {
+                // Ignore malformed URL fragments and leave the current editor value intact.
+            }
+            UpdateMath(mathsEditor.value);
+        };
+
         const updateHandler = () => {
             clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => {
                 UpdateMath(mathsEditor.value);
+                const encodedHash = `#${encodeURIComponent(mathsEditor.value)}`;
+                const urlTarget = getUrlTarget();
+
                 try {
-                    if (window.parent) {
-                        window.parent.location.hash = encodeURIComponent(mathsEditor.value);
-                    } else {
-                        window.location.hash = encodeURIComponent(mathsEditor.value);
+                    if (urlTarget.history && typeof urlTarget.history.replaceState === 'function') {
+                        urlTarget.history.replaceState(null, '', encodedHash);
+                        return;
                     }
                 } catch (err) {
-                    window.location.hash = encodeURIComponent(mathsEditor.value);
+                    // Fall back to replacing the URL when the History API is unavailable.
+                }
+
+                try {
+                    if (urlTarget.location && typeof urlTarget.location.replace === 'function') {
+                        urlTarget.location.replace(encodedHash);
+                    }
+                } catch (err) {
+                    // Ignore inaccessible URL state.
                 }
             }, 300);
         };
@@ -78,22 +134,18 @@ if (typeof window !== 'undefined') {
             }
         });
 
+        const hashChangeTarget = getUrlTarget();
         try {
-            if (window.parent && window.parent.location.hash) {
-                mathsEditor.value = decodeURIComponent(window.parent.location.hash.substr(1));
-            } else if (window.location.hash) {
-                mathsEditor.value = decodeURIComponent(window.location.hash.substr(1));
+            if (hashChangeTarget && typeof hashChangeTarget.addEventListener === 'function') {
+                hashChangeTarget.addEventListener("hashchange", updateFromHash);
+            } else {
+                window.addEventListener("hashchange", updateFromHash);
             }
         } catch (err) {
-            if (window.location.hash) {
-                mathsEditor.value = decodeURIComponent(window.location.hash.substr(1));
-            }
+            window.addEventListener("hashchange", updateFromHash);
         }
 
-        const mathOutputP = document.querySelector("#math-output p");
-        if (mathOutputP) {
-            UpdateMath(mathsEditor.value);
-        }
+        updateFromHash();
 
         document.querySelectorAll(".pre-made").forEach(btn => {
             btn.addEventListener("click", (e) => {

--- a/tests/editor-sync.test.js
+++ b/tests/editor-sync.test.js
@@ -20,6 +20,40 @@ function createBrowserHarness() {
     const mathsEditor = new FakeEventTarget();
     mathsEditor.value = 'x';
 
+    let currentHash = '';
+    let historyIndex = 0;
+    const historyEntries = [''];
+    const normalizeHash = value => {
+        if (!value) {
+            return '';
+        }
+
+        const stringValue = String(value);
+        return stringValue.startsWith('#') ? stringValue : `#${stringValue}`;
+    };
+    const history = {
+        get length() {
+            return historyEntries.length;
+        },
+        replaceState: jest.fn((state, title, url) => {
+            const urlString = String(url);
+            const hashStart = urlString.indexOf('#');
+            currentHash = hashStart === -1 ? '' : urlString.slice(hashStart);
+            historyEntries[historyIndex] = currentHash;
+        })
+    };
+    const location = {};
+    Object.defineProperty(location, 'hash', {
+        configurable: true,
+        get: () => currentHash,
+        set: value => {
+            currentHash = normalizeHash(value);
+            historyEntries.splice(historyIndex + 1);
+            historyEntries.push(currentHash);
+            historyIndex = historyEntries.length - 1;
+        }
+    });
+
     const output = { textContent: '' };
     const document = new FakeEventTarget();
     document.createElement = () => ({
@@ -32,17 +66,25 @@ function createBrowserHarness() {
     document.querySelector = selector => selector === '#math-output p' ? output : null;
     document.querySelectorAll = () => [];
 
+    const windowListeners = new Map();
+    const addWindowEventListener = jest.fn((type, listener) => {
+        const listeners = windowListeners.get(type) || [];
+        listeners.push(listener);
+        windowListeners.set(type, listeners);
+    });
+
     const originalGlobals = new Map();
-    for (const name of ['window', 'document', 'parent', 'location', 'ga', 'addEventListener']) {
+    for (const name of ['window', 'document', 'parent', 'location', 'history', 'ga', 'addEventListener']) {
         originalGlobals.set(name, global[name]);
     }
 
     global.window = global;
     global.document = document;
-    global.parent = { location: { hash: '' } };
-    global.location = { hash: '' };
+    global.parent = { history, location, addEventListener: addWindowEventListener };
+    global.location = location;
+    global.history = history;
     global.ga = jest.fn();
-    global.addEventListener = jest.fn();
+    global.addEventListener = addWindowEventListener;
 
     jest.resetModules();
     require('../public_html/main.js');
@@ -51,7 +93,14 @@ function createBrowserHarness() {
     return {
         mathsEditor,
         output,
+        history,
         parent: global.parent,
+        dispatchHashchange(hash) {
+            currentHash = normalizeHash(hash);
+            for (const listener of windowListeners.get('hashchange') || []) {
+                listener({ type: 'hashchange' });
+            }
+        },
         restore() {
             jest.resetModules();
             for (const [name, value] of originalGlobals) {
@@ -92,7 +141,46 @@ describe('editor synchronization', () => {
 
         jest.advanceTimersByTime(1);
         expect(activeHarness.output.textContent).toBe('$$\\displaystyle{x+y}$$');
-        expect(activeHarness.parent.location.hash).toBe(encodeURIComponent('x+y'));
+        expect(activeHarness.parent.location.hash).toBe(`#${encodeURIComponent('x+y')}`);
+    });
+
+    it('replaces the URL hash without adding a history entry', () => {
+        activeHarness = createBrowserHarness();
+
+        activeHarness.mathsEditor.value = 'a';
+        activeHarness.mathsEditor.dispatchEvent({ type: 'input' });
+        jest.advanceTimersByTime(300);
+
+        expect(activeHarness.history.length).toBe(1);
+        expect(activeHarness.history.replaceState).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores the editor and preview when the URL hash changes', () => {
+        activeHarness = createBrowserHarness();
+
+        activeHarness.dispatchHashchange(encodeURIComponent('x^2'));
+
+        expect(activeHarness.mathsEditor.value).toBe('x^2');
+        expect(activeHarness.output.textContent).toBe('$$\\displaystyle{x^2}$$');
+    });
+
+    it('ignores malformed URL hash encoding during navigation', () => {
+        activeHarness = createBrowserHarness();
+
+        expect(() => activeHarness.dispatchHashchange('%E0%A4%A')).not.toThrow();
+        expect(activeHarness.mathsEditor.value).toBe('x');
+    });
+
+    it('cancels a pending URL write when navigation restores a hash', () => {
+        activeHarness = createBrowserHarness();
+
+        activeHarness.mathsEditor.value = 'a';
+        activeHarness.mathsEditor.dispatchEvent({ type: 'input' });
+        activeHarness.dispatchHashchange(encodeURIComponent('x^2'));
+        jest.advanceTimersByTime(300);
+
+        expect(activeHarness.mathsEditor.value).toBe('x^2');
+        expect(activeHarness.history.replaceState).not.toHaveBeenCalled();
     });
 
 });


### PR DESCRIPTION
## Summary

- replace debounced hash writes with History API replacement so edits do not stack browser history entries
- restore the editor and preview on hashchange, including safe handling of malformed fragments
- cancel pending writes when browser navigation restores a hash

## Validation

- `npm test -- --runInBand --roots tests`
- `node --check public_html/main.js`
- `git diff --check`

Closes #5