### PR TITLE
Fix KaTeX parse error when editor TeX contains % (#4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.3.0",
+        "katex": "^0.16.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1927,6 +1928,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3155,6 +3166,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
+      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/leven": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
   "scripts": {
     "test": "jest"
   },
+  "jest": {
+    "testMatch": ["<rootDir>/tests/**/*.test.js"]
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "jest": "^30.3.0"
+    "jest": "^30.3.0",
+    "katex": "^0.16.9"
   }
 }

--- a/public_html/main.js
+++ b/public_html/main.js
@@ -1,5 +1,5 @@
 function formatMath(TeX) {
-    return (TeX && TeX !== "\\") ? "\\displaystyle{" + TeX + "}" : "";
+    return (TeX && TeX !== "\\") ? TeX : "";
 }
 
 if (typeof window !== 'undefined') {

--- a/tests/editor-sync.test.js
+++ b/tests/editor-sync.test.js
@@ -136,11 +136,11 @@ describe('editor synchronization', () => {
         activeHarness.mathsEditor.dispatchEvent({ type: 'input' });
 
         jest.advanceTimersByTime(299);
-        expect(activeHarness.output.textContent).toBe('$$\\displaystyle{x}$$');
+        expect(activeHarness.output.textContent).toBe('$$x$$');
         expect(activeHarness.parent.location.hash).toBe('');
 
         jest.advanceTimersByTime(1);
-        expect(activeHarness.output.textContent).toBe('$$\\displaystyle{x+y}$$');
+        expect(activeHarness.output.textContent).toBe('$$x+y$$');
         expect(activeHarness.parent.location.hash).toBe(`#${encodeURIComponent('x+y')}`);
     });
 
@@ -161,7 +161,7 @@ describe('editor synchronization', () => {
         activeHarness.dispatchHashchange(encodeURIComponent('x^2'));
 
         expect(activeHarness.mathsEditor.value).toBe('x^2');
-        expect(activeHarness.output.textContent).toBe('$$\\displaystyle{x^2}$$');
+        expect(activeHarness.output.textContent).toBe('$$x^2$$');
     });
 
     it('ignores malformed URL hash encoding during navigation', () => {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,9 +1,18 @@
+const katex = require('katex');
 const { formatMath } = require('../public_html/main.js');
 
 describe('formatMath', () => {
-    it('returns formatted math with displaystyle when valid TeX is provided', () => {
-        expect(formatMath('x^2')).toBe('\\displaystyle{x^2}');
-        expect(formatMath('\\frac{1}{2}')).toBe('\\displaystyle{\\frac{1}{2}}');
+    it('returns the TeX unchanged when valid TeX is provided', () => {
+        expect(formatMath('x^2')).toBe('x^2');
+        expect(formatMath('\\frac{1}{2}')).toBe('\\frac{1}{2}');
+    });
+
+    it('does not make KaTeX fail when TeX contains a percent comment', () => {
+        const opts = { throwOnError: true, displayMode: true };
+        expect(() => katex.renderToString('%', opts)).not.toThrow();
+        expect(() => katex.renderToString(formatMath('%'), opts)).not.toThrow();
+        expect(() => katex.renderToString('x%', opts)).not.toThrow();
+        expect(() => katex.renderToString(formatMath('x%'), opts)).not.toThrow();
     });
 
     it('returns empty string when TeX is empty', () => {


### PR DESCRIPTION
Fixes #4

## Summary

`formatMath` wrapped editor TeX in `\displaystyle{...}`. A `%` in the source is a TeX comment, so it commented out the closing `}`. KaTeX then reported `Expected '}', got 'EOF'` for input it would otherwise accept.

`UpdateMath` already sets `displayMode: true`, so the extra group was redundant. Pass the editor value through unchanged.

## Test plan

- [x] Regression: KaTeX 0.16.9 `renderToString(formatMath('%'))` and `formatMath('x%')` with `throwOnError: true`, `displayMode: true`
- [x] Existing `formatMath` and editor-sync tests updated for pass-through
- [x] `npm test`