### PR TITLE
Fix uncaught URIError in URL hash write path (#2)

### DIFF
--- a/public_html/main.js
+++ b/public_html/main.js
@@ -81,7 +81,14 @@ if (typeof window !== 'undefined') {
             clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => {
                 UpdateMath(mathsEditor.value);
-                const encodedHash = `#${encodeURIComponent(mathsEditor.value)}`;
+                let encodedHash;
+                try {
+                    encodedHash = `#${encodeURIComponent(mathsEditor.value)}`;
+                } catch (err) {
+                    // Skip the hash write when the value cannot be encoded,
+                    // e.g. unpaired UTF-16 surrogates. The preview already updated.
+                    return;
+                }
                 const urlTarget = getUrlTarget();
 
                 try {

--- a/tests/editor-sync.test.js
+++ b/tests/editor-sync.test.js
@@ -16,13 +16,10 @@ class FakeEventTarget {
     }
 }
 
-function createBrowserHarness() {
+function createBrowserHarness(initialHash = '') {
     const mathsEditor = new FakeEventTarget();
     mathsEditor.value = 'x';
 
-    let currentHash = '';
-    let historyIndex = 0;
-    const historyEntries = [''];
     const normalizeHash = value => {
         if (!value) {
             return '';
@@ -31,6 +28,9 @@ function createBrowserHarness() {
         const stringValue = String(value);
         return stringValue.startsWith('#') ? stringValue : `#${stringValue}`;
     };
+    let currentHash = initialHash ? normalizeHash(initialHash) : '';
+    let historyIndex = 0;
+    const historyEntries = [''];
     const history = {
         get length() {
             return historyEntries.length;
@@ -169,6 +169,35 @@ describe('editor synchronization', () => {
 
         expect(() => activeHarness.dispatchHashchange('%E0%A4%A')).not.toThrow();
         expect(activeHarness.mathsEditor.value).toBe('x');
+    });
+
+    it('keeps the default formula and binds listeners when the initial hash is malformed', () => {
+        activeHarness = createBrowserHarness('%E0%A4%A');
+
+        expect(activeHarness.mathsEditor.value).toBe('x');
+        expect(activeHarness.output.textContent).toBe('$$x$$');
+
+        // Listeners must still be bound after the failed restore.
+        activeHarness.mathsEditor.value = 'x^2';
+        activeHarness.mathsEditor.dispatchEvent({ type: 'input' });
+        jest.advanceTimersByTime(300);
+
+        expect(activeHarness.mathsEditor.value).toBe('x^2');
+        expect(activeHarness.parent.location.hash).toBe(`#${encodeURIComponent('x^2')}`);
+    });
+
+    it('skips the hash write and still updates the preview for unpaired surrogates', () => {
+        activeHarness = createBrowserHarness();
+
+        expect(() => {
+            activeHarness.mathsEditor.value = 'x\uD800y';
+            activeHarness.mathsEditor.dispatchEvent({ type: 'input' });
+            jest.advanceTimersByTime(300);
+        }).not.toThrow();
+
+        expect(activeHarness.output.textContent).toBe('$$x\uD800y$$');
+        expect(activeHarness.history.replaceState).not.toHaveBeenCalled();
+        expect(activeHarness.parent.location.hash).toBe('');
     });
 
     it('cancels a pending URL write when navigation restores a hash', () => {


### PR DESCRIPTION
## Summary

Fixes #2 (write path) and hardens the read path with regression tests.

- **Write path (the remaining bug):** `encodeURIComponent(mathsEditor.value)` was computed outside every try/catch in the debounced timeout, so an editor value containing an unpaired UTF-16 surrogate (e.g. `"\uD800"`) threw `URIError: URI malformed` uncaught, aborting the hash write. The encode now runs in its own try/catch that **skips the URL write** on failure — the preview has already updated, per the issue's prescribed fix.
- **Read path:** already fixed by the earlier hash-sync refactor (`decodeURIComponent` inside `updateFromHash`'s non-rethrowing catch), so malformed fragments like `#%`, `#%ZZ`, `#%E0%A4%A` keep the default formula and still bind editor listeners. This PR locks that behaviour down with a regression test for the init-time path.

## Validation

- New regression tests in `tests/editor-sync.test.js` (existing browser-harness seam):
  - unpaired surrogate on input → no throw, preview updates, hash write skipped (failed with `URIError: URI malformed` at `main.js:84` before the fix, passes after);
  - malformed initial hash → default formula kept, listeners still bound (already passing, kept as a guard).
- Full suite: `npm test` → 3 suites, 12 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
