### PR TITLE
Fix empty URL fragment restore (#3)

### DIFF
--- a/public_html/main.js
+++ b/public_html/main.js
@@ -69,8 +69,11 @@ if (typeof window !== 'undefined') {
             clearTimeout(debounceTimer);
             try {
                 const encodedHash = getEncodedHash();
-                const value = encodedHash === null ? initialEditorValue : decodeURIComponent(encodedHash);
-                mathsEditor.value = value;
+                if (encodedHash === null) {
+                    mathsEditor.value = initialEditorValue;
+                } else if (encodedHash !== '') {
+                    mathsEditor.value = decodeURIComponent(encodedHash);
+                }
             } catch (err) {
                 // Ignore malformed URL fragments and leave the current editor value intact.
             }

--- a/tests/editor-sync.test.js
+++ b/tests/editor-sync.test.js
@@ -16,9 +16,11 @@ class FakeEventTarget {
     }
 }
 
-function createBrowserHarness(initialHash = '') {
+const DEFAULT_QUADRATIC_FORMULA = String.raw`\frac{-b\pm\sqrt{b^2-4ac}}{2a}`;
+
+function createBrowserHarness(initialHash = '', initialEditorValue = 'x') {
     const mathsEditor = new FakeEventTarget();
-    mathsEditor.value = 'x';
+    mathsEditor.value = initialEditorValue;
 
     const normalizeHash = value => {
         if (!value) {
@@ -184,6 +186,13 @@ describe('editor synchronization', () => {
 
         expect(activeHarness.mathsEditor.value).toBe('x^2');
         expect(activeHarness.parent.location.hash).toBe(`#${encodeURIComponent('x^2')}`);
+    });
+
+    it('keeps the default formula when the initial hash is bare', () => {
+        activeHarness = createBrowserHarness('#', DEFAULT_QUADRATIC_FORMULA);
+
+        expect(activeHarness.mathsEditor.value).toBe(DEFAULT_QUADRATIC_FORMULA);
+        expect(activeHarness.output.textContent).toBe(`$$${DEFAULT_QUADRATIC_FORMULA}$$`);
     });
 
     it('skips the hash write and still updates the preview for unpaired surrogates', () => {


### PR DESCRIPTION
## Summary

- Preserve the editor value when the URL fragment is only `#`.
- Add browser-harness regression coverage for the default quadratic formula.

## Root cause

`location.hash` is truthy for `#`, but stripping the marker produces an empty string. The loader decoded and assigned that empty string over the initial editor value. Empty fragments now skip assignment while a missing fragment keeps the existing initial-value behavior.

## Validation

- `npm test -- --runInBand` — 3 suites, 13 tests passed.
- The standalone reproduction passed three consecutive runs.
- `git diff --check` passed.

Fixes #3