### PR TITLE
Fix auto-paired closing delimiter duplication

### DIFF
--- a/public_html/main.js
+++ b/public_html/main.js
@@ -123,11 +123,17 @@ if (typeof window !== 'undefined') {
                 '[': ']',
                 '{': '}'
             };
+            const closingPairs = {
+                ')': '(',
+                ']': '[',
+                '}': '{'
+            };
+            const start = this.selectionStart;
+            const end = this.selectionEnd;
+            const val = this.value;
+
             if (pairs[e.key]) {
                 e.preventDefault();
-                const start = this.selectionStart;
-                const end = this.selectionEnd;
-                const val = this.value;
                 const selectedText = val.substring(start, end);
                 const insertStr = e.key + selectedText + pairs[e.key];
                 
@@ -140,6 +146,21 @@ if (typeof window !== 'undefined') {
                     this.selectionEnd = end + 1;
                 }
                 
+                updateHandler();
+                return;
+            }
+
+            if (closingPairs[e.key] && start === end && val[start] === e.key) {
+                e.preventDefault();
+                this.selectionStart = this.selectionEnd = start + 1;
+                updateHandler();
+                return;
+            }
+
+            if (e.key === 'Backspace' && start === end && start > 0 && pairs[val[start - 1]] === val[start]) {
+                e.preventDefault();
+                this.value = val.substring(0, start - 1) + val.substring(start + 1);
+                this.selectionStart = this.selectionEnd = start - 1;
                 updateHandler();
             }
         });

--- a/tests/editor-sync.test.js
+++ b/tests/editor-sync.test.js
@@ -11,8 +11,9 @@ class FakeEventTarget {
 
     dispatchEvent(event) {
         for (const listener of this.listeners.get(event.type) || []) {
-            listener(event);
+            listener.call(this, event);
         }
+        return !event.defaultPrevented;
     }
 }
 
@@ -21,6 +22,8 @@ const DEFAULT_QUADRATIC_FORMULA = String.raw`\frac{-b\pm\sqrt{b^2-4ac}}{2a}`;
 function createBrowserHarness(initialHash = '', initialEditorValue = 'x') {
     const mathsEditor = new FakeEventTarget();
     mathsEditor.value = initialEditorValue;
+    mathsEditor.selectionStart = 0;
+    mathsEditor.selectionEnd = 0;
 
     const normalizeHash = value => {
         if (!value) {
@@ -116,6 +119,35 @@ function createBrowserHarness(initialHash = '', initialEditorValue = 'x') {
     };
 }
 
+function dispatchEditorKey(mathsEditor, key) {
+    const event = {
+        type: 'keydown',
+        key,
+        defaultPrevented: false,
+        preventDefault() {
+            this.defaultPrevented = true;
+        }
+    };
+    const shouldApplyNativeAction = mathsEditor.dispatchEvent(event);
+
+    if (shouldApplyNativeAction) {
+        const start = mathsEditor.selectionStart;
+        const end = mathsEditor.selectionEnd;
+
+        if (key === 'Backspace' && start === end && start > 0) {
+            mathsEditor.value = mathsEditor.value.slice(0, start - 1) + mathsEditor.value.slice(end);
+            mathsEditor.selectionStart = mathsEditor.selectionEnd = start - 1;
+        } else {
+            mathsEditor.value = mathsEditor.value.slice(0, start) + key + mathsEditor.value.slice(end);
+            mathsEditor.selectionStart = mathsEditor.selectionEnd = start + key.length;
+        }
+
+        mathsEditor.dispatchEvent({ type: 'input' });
+    }
+
+    return event;
+}
+
 describe('editor synchronization', () => {
     let activeHarness;
 
@@ -129,6 +161,80 @@ describe('editor synchronization', () => {
             activeHarness = null;
         }
         jest.useRealTimers();
+    });
+
+    it('skips hand-typed matching closers and preserves mismatched closers', () => {
+        activeHarness = createBrowserHarness('', '');
+        const { mathsEditor } = activeHarness;
+
+        for (const [opener, closer] of [['(', ')'], ['[', ']'], ['{', '}']]) {
+            mathsEditor.value = '';
+            mathsEditor.selectionStart = mathsEditor.selectionEnd = 0;
+
+            dispatchEditorKey(mathsEditor, opener);
+            dispatchEditorKey(mathsEditor, 'x');
+            const closerEvent = dispatchEditorKey(mathsEditor, closer);
+
+            expect(closerEvent.defaultPrevented).toBe(true);
+            expect(mathsEditor.value).toBe(`${opener}x${closer}`);
+            expect(mathsEditor.selectionStart).toBe(3);
+            expect(mathsEditor.selectionEnd).toBe(3);
+        }
+
+        mathsEditor.value = '';
+        mathsEditor.selectionStart = mathsEditor.selectionEnd = 0;
+        dispatchEditorKey(mathsEditor, '(');
+        dispatchEditorKey(mathsEditor, ']');
+
+        expect(mathsEditor.value).toBe('(])');
+        expect(mathsEditor.selectionStart).toBe(2);
+        expect(mathsEditor.selectionEnd).toBe(2);
+    });
+
+    it('deletes an empty auto-paired delimiter as a unit', () => {
+        activeHarness = createBrowserHarness('', '');
+        const { mathsEditor } = activeHarness;
+
+        for (const opener of ['(', '[', '{']) {
+            mathsEditor.value = '';
+            mathsEditor.selectionStart = mathsEditor.selectionEnd = 0;
+
+            dispatchEditorKey(mathsEditor, opener);
+            const backspaceEvent = dispatchEditorKey(mathsEditor, 'Backspace');
+
+            expect(backspaceEvent.defaultPrevented).toBe(true);
+            expect(mathsEditor.value).toBe('');
+            expect(mathsEditor.selectionStart).toBe(0);
+            expect(mathsEditor.selectionEnd).toBe(0);
+        }
+    });
+
+    it('wraps a selection with an auto-paired delimiter', () => {
+        activeHarness = createBrowserHarness('', 'abc');
+        const { mathsEditor } = activeHarness;
+        mathsEditor.selectionStart = 0;
+        mathsEditor.selectionEnd = 3;
+
+        const openerEvent = dispatchEditorKey(mathsEditor, '(');
+
+        expect(openerEvent.defaultPrevented).toBe(true);
+        expect(mathsEditor.value).toBe('(abc)');
+        expect(mathsEditor.selectionStart).toBe(1);
+        expect(mathsEditor.selectionEnd).toBe(4);
+    });
+
+    it('keeps the corrected value, preview, and shareable hash synchronized', () => {
+        activeHarness = createBrowserHarness('', '');
+        const { mathsEditor, output, parent } = activeHarness;
+
+        dispatchEditorKey(mathsEditor, '(');
+        dispatchEditorKey(mathsEditor, 'x');
+        dispatchEditorKey(mathsEditor, ')');
+        jest.advanceTimersByTime(300);
+
+        expect(mathsEditor.value).toBe('(x)');
+        expect(output.textContent).toBe('$$\u0028x\u0029$$');
+        expect(parent.location.hash).toBe(`#${encodeURIComponent('(x)')}`);
     });
 
     it('updates the preview and URL hash for input events', () => {


### PR DESCRIPTION
## Summary

- Skip over an auto-inserted `)`, `]`, or `}` when the matching closer is typed.
- Delete empty auto-paired delimiters together on Backspace.
- Add regression coverage for all delimiter pairs, mismatches, selection wrapping, preview, and URL hash synchronization.

The confirmed root cause was the keydown handler allowing native insertion of a matching closer while the caret was immediately before the auto-inserted closer.

Fixes #14

## Validation

- `npm test -- --runInBand` (17/17)
- Live Chrome replay of `(x)`, `[x]`, `{x}`, paired Backspace, and selection wrapping