### PR TITLE
fix: stop cross-origin embeds navigating the host page away

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "test:e2e": "node tests/editor-undo.e2e.js"
+    "test:e2e": "node tests/editor-undo.e2e.js",
+    "test:e2e:embed": "node tests/embed-crossorigin.e2e.js"
   },
   "jest": {
     "testMatch": [

--- a/public_html/main.js
+++ b/public_html/main.js
@@ -33,8 +33,13 @@ if (typeof window !== 'undefined') {
 
         const getUrlTarget = () => {
             try {
-                if (window.parent && window.parent.location) {
-                    return window.parent;
+                // Accessing `window.parent.location` does not throw cross-origin, but
+                // reading its members does. Only target the parent when its URL is
+                // genuinely readable (same origin); otherwise updating it would
+                // navigate the host page away (#20).
+                const parent = window.parent;
+                if (parent && typeof parent.location.hash === 'string') {
+                    return parent;
                 }
             } catch (err) {
                 // Fall back to the current window when the parent is inaccessible.

--- a/tests/embed-crossorigin.e2e.js
+++ b/tests/embed-crossorigin.e2e.js
@@ -1,0 +1,243 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const puppeteer = require('puppeteer-core');
+
+const publicDirectory = path.join(__dirname, '..', 'public_html');
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+function findChrome() {
+    const candidates = [
+        process.env.CHROME_PATH,
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        'google-chrome',
+        'chromium',
+        'chromium-browser'
+    ].filter(Boolean);
+
+    for (const candidate of candidates) {
+        if (path.isAbsolute(candidate)) {
+            if (fs.existsSync(candidate)) {
+                return candidate;
+            }
+            continue;
+        }
+
+        try {
+            return execFileSync('which', [candidate], { encoding: 'utf8' }).trim();
+        } catch (error) {
+            // Try the next browser name.
+        }
+    }
+
+    throw new Error('A Chrome or Chromium executable is required for the cross-origin embed regression test');
+}
+
+function contentType(filePath) {
+    return {
+        '.css': 'text/css',
+        '.html': 'text/html',
+        '.js': 'text/javascript'
+    }[path.extname(filePath)] || 'application/octet-stream';
+}
+
+function startServer() {
+    const server = http.createServer((request, response) => {
+        let requestPath;
+        try {
+            requestPath = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+        } catch (error) {
+            response.writeHead(400);
+            response.end();
+            return;
+        }
+
+        // Dynamically generated embed host pages, one per origin variant. The iframe
+        // origin is passed as a query parameter so the test can run on ephemeral ports.
+        if (requestPath === '/host.html') {
+            const embedUrl = new URL(request.url, 'http://localhost').searchParams.get('embed');
+            const hostOrigin = new URL(`http://${request.headers.host || 'localhost'}`).origin;
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(`<!DOCTYPE html>
+<html>
+<head><title>Host Page</title></head>
+<body>
+<h1>Host page</h1>
+<iframe id="latex-frame" src="${embedUrl}" width="900" height="500"></iframe>
+</body>
+</html>`);
+            return;
+        }
+
+        const relativePath = requestPath === '/' ? '/index.html' : requestPath;
+        const filePath = path.resolve(publicDirectory, `.${relativePath}`);
+        if (!filePath.startsWith(`${publicDirectory}${path.sep}`)) {
+            response.writeHead(403);
+            response.end();
+            return;
+        }
+
+        fs.readFile(filePath, (error, contents) => {
+            if (error) {
+                response.writeHead(error.code === 'ENOENT' ? 404 : 500);
+                response.end();
+                return;
+            }
+
+            response.writeHead(200, { 'Content-Type': contentType(filePath) });
+            response.end(contents);
+        });
+    });
+
+    // Listen on all interfaces so both `127.0.0.1` and `localhost` reach the same
+    // server on the same port while remaining distinct origins for the browser.
+    return new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, () => {
+            server.removeListener('error', reject);
+            resolve({ server, port: server.address().port });
+        });
+    });
+}
+
+async function findAppFrame(page, port, embedHost = 'localhost', attempts = 40) {
+    for (let index = 0; index < attempts; index += 1) {
+        const frame = page.frames().find(candidate => candidate.url().includes(`${embedHost}:${port}/index.html`));
+        if (frame) {
+            try {
+                await frame.evaluate(() => Boolean(document.getElementById('maths-editor')));
+                return frame;
+            } catch (error) {
+                // Frame may still be initialising; retry.
+            }
+        }
+        await sleep(250);
+    }
+    throw new Error('Embedded app frame not found');
+}
+
+async function topLevelState(page) {
+    return page.evaluate(() => ({
+        url: location.href,
+        title: document.title,
+        historyLength: history.length
+    }));
+}
+
+async function typeInEmbeddedEditor(page, frame, text, attempts = 5) {
+    for (let index = 0; index < attempts; index += 1) {
+        try {
+            await frame.evaluate(() => {
+                const editor = document.getElementById('maths-editor');
+                if (!editor) {
+                    throw new Error('editor not ready');
+                }
+                editor.focus();
+                editor.setSelectionRange(editor.value.length, editor.value.length);
+            });
+            break;
+        } catch (error) {
+            if (index === attempts - 1) {
+                throw error;
+            }
+            await sleep(500);
+        }
+    }
+    await page.keyboard.type(text, { delay: 30 });
+    await sleep(700);
+}
+
+async function runScenario(browser, { server, port, embedHost }) {
+    const page = await browser.newPage();
+    const embedUrl = `http://${embedHost}:${port}/index.html`;
+    const hostUrl = `http://127.0.0.1:${port}/host.html?embed=${encodeURIComponent(embedUrl)}`;
+
+    try {
+        await page.goto(hostUrl, { waitUntil: 'domcontentloaded' });
+        const frame = await findAppFrame(page, port);
+        const before = await topLevelState(page);
+
+        await typeInEmbeddedEditor(page, frame, 'x');
+        const after = await topLevelState(page);
+
+        let frameState = null;
+        try {
+            frameState = await frame.evaluate(() => ({
+                url: location.href,
+                value: document.getElementById('maths-editor').value
+            }));
+        } catch (error) {
+            // Frame detached: the top-level navigation destroyed the embed context,
+            // which is itself the symptom under test.
+        }
+
+        // The host page must never be navigated or mutated by the embedded editor.
+        assert.equal(after.url, before.url, 'top-level page URL must stay on the host page');
+        assert.equal(after.title, before.title, 'top-level page title must stay the host page title');
+        assert.equal(after.historyLength, before.historyLength, 'top-level history must not gain entries');
+        assert.ok(after.url.startsWith(`http://127.0.0.1:${port}/`), 'top-level page must remain on its own origin');
+
+        // At most, the embedded instance's own state changes: it keeps the formula
+        // in its own fragment.
+        if (frameState) {
+            assert.match(frameState.url, /#/, 'embedded instance should track its own URL fragment');
+            assert.equal(
+                decodeURIComponent(frameState.url.split('#').pop() || ''),
+                frameState.value,
+                'embedded instance should carry the formula in its own fragment'
+            );
+        }
+
+        return after;
+    } finally {
+        await page.close();
+    }
+}
+
+async function run() {
+    const { server, port } = await startServer();
+    let browser;
+
+    try {
+        browser = await puppeteer.launch({
+            executablePath: findChrome(),
+            headless: 'new',
+            userDataDir: `/tmp/instantlatex-issue-20-e2e-${Date.now()}`,
+            args: ['--no-first-run', '--disable-extensions']
+        });
+
+        // Cross-origin embed (127.0.0.1 host, localhost iframe): the scenario from #20.
+        await runScenario(browser, { server, port, embedHost: 'localhost' });
+        console.log('cross-origin embed: host page survived typing; app kept its own fragment');
+
+        // Same-origin embed: the shareable fragment on the host page must be preserved.
+        const page = await browser.newPage();
+        const embedUrl = `http://127.0.0.1:${port}/index.html`;
+        const hostUrl = `http://127.0.0.1:${port}/host.html?embed=${encodeURIComponent(embedUrl)}`;
+        await page.goto(hostUrl, { waitUntil: 'domcontentloaded' });
+        const frame = await findAppFrame(page, port, '127.0.0.1');
+        await typeInEmbeddedEditor(page, frame, 'x');
+        const state = await topLevelState(page);
+        const editorValue = await frame.evaluate(() => document.getElementById('maths-editor').value);
+        assert.equal(
+            decodeURIComponent(state.url.split('#').pop() || ''),
+            editorValue,
+            'same-origin embed should still publish the formula to the host page fragment'
+        );
+        assert.ok(state.url.startsWith(`http://127.0.0.1:${port}/`));
+        console.log('same-origin embed: host page fragment still shareable');
+        await page.close();
+    } finally {
+        if (browser) {
+            await browser.close();
+        }
+        await new Promise(resolve => server.close(resolve));
+    }
+}
+
+run().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Typing in a cross-origin embedded InstantLaTeX instance navigated the host page away entirely: the top-level page was replaced by the app's URL with the formula fragment, and the host page was replaced in session history (Back landed on `about:blank`).

## Root cause

`getUrlTarget()` picked `window.parent` whenever the truthiness check `window.parent && window.parent.location` passed — but that check does **not** throw cross-origin (only reading `location`'s members does). So a cross-origin embed targeted the host page's URL, `history.replaceState` there threw `SecurityError`, and the fallback meant for "History API unavailable" ran `urlTarget.location.replace('#…')` — an operation cross-origin code *is* allowed to perform. Chrome resolves a fragment-only URL against the **calling** context, so the top-level page navigated wholesale to the app's origin.

Verified on the failing build with in-frame probes: `parentLocationTruthy: true`, `parentHashRead: SecurityError`, `parentReplaceState: SecurityError`, `parentLocationReplaceType: 'function'`.

## Fix

`getUrlTarget()` now targets the parent only when its URL is actually readable (same origin) by attempting `parent.location.hash`; otherwise it falls back to the instance's own window.

- Same-origin embeds keep publishing the shareable fragment to the host page (existing behaviour preserved).
- Cross-origin embeds now track the formula in their own fragment and never touch the host page's location or history.

## Testing

- New regression test `tests/embed-crossorigin.e2e.js` (Puppeteer): drives a cross-origin embed (127.0.0.1 host page, localhost iframe) and asserts the top-level page URL, title, and history length are untouched after typing; a same-origin control asserts the host-page fragment is still shareable. Red on `0877986`, green with the fix (deterministic across 3 runs).
- `npm test` (19 jest tests) and `npm run test:e2e` pass.

Note: jsdom has no cross-origin browser context, so no unit seam exists for this bug pattern; the e2e seam is the correct one.

Fixes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
