### PR TITLE
test: bound Jest workers and clean browser profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # Agent Instructions
 
+## Shared Fleet host
+
+Fleet runs this repository with other autonomous jobs on one macOS host.
+
+- Run Jest with `npm test -- --maxWorkers=2`.
+- Run browser tests with `npm run test:e2e`.
+- Give each browser test run a unique Chrome profile under `/tmp`.
+- Remove the exact profile directory in the test cleanup after Chrome closes.
+- Preserve all other files and directories under `/tmp`.
+
 ## Agent skills
 
 ### Issue tracker

--- a/tests/editor-undo.e2e.js
+++ b/tests/editor-undo.e2e.js
@@ -152,14 +152,20 @@ async function assertSynchronized(page, expectedValue) {
 }
 
 async function run() {
-    const { server, url } = await startServer();
+    const profileDirectory = fs.mkdtempSync(path.join('/tmp', 'instantlatex-issue-15-e2e-'));
+    let server;
     let browser;
+    let testError;
+    let cleanupError;
 
     try {
+        const startedServer = await startServer();
+        server = startedServer.server;
+        const { url } = startedServer;
         browser = await puppeteer.launch({
             executablePath: findChrome(),
             headless: 'new',
-            userDataDir: `/tmp/instantlatex-issue-15-e2e-${Date.now()}`,
+            userDataDir: profileDirectory,
             args: ['--no-first-run', '--disable-extensions']
         });
         const page = await browser.newPage();
@@ -211,11 +217,44 @@ async function run() {
 
         assert.deepEqual(pageErrors, []);
         console.log('editor undo/redo regression scenarios passed');
+    } catch (error) {
+        testError = error;
     } finally {
-        if (browser) {
-            await browser.close();
+        try {
+            if (browser) {
+                await browser.close();
+            }
+        } catch (error) {
+            cleanupError = error;
         }
-        await new Promise(resolve => server.close(resolve));
+
+        try {
+            fs.rmSync(profileDirectory, { recursive: true, force: true });
+            assert.equal(
+                fs.existsSync(profileDirectory),
+                false,
+                `browser profile should be removed after the test: ${profileDirectory}`
+            );
+        } catch (error) {
+            cleanupError ||= error;
+        }
+
+        if (server) {
+            try {
+                await new Promise((resolve, reject) => {
+                    server.close(error => error ? reject(error) : resolve());
+                });
+            } catch (error) {
+                cleanupError ||= error;
+            }
+        }
+    }
+
+    if (testError) {
+        throw testError;
+    }
+    if (cleanupError) {
+        throw cleanupError;
     }
 }
 

--- a/tests/embed-crossorigin.e2e.js
+++ b/tests/embed-crossorigin.e2e.js
@@ -197,14 +197,20 @@ async function runScenario(browser, { server, port, embedHost }) {
 }
 
 async function run() {
-    const { server, port } = await startServer();
+    const profileDirectory = fs.mkdtempSync(path.join('/tmp', 'instantlatex-issue-20-e2e-'));
+    let server;
     let browser;
+    let testError;
+    let cleanupError;
 
     try {
+        const startedServer = await startServer();
+        server = startedServer.server;
+        const { port } = startedServer;
         browser = await puppeteer.launch({
             executablePath: findChrome(),
             headless: 'new',
-            userDataDir: `/tmp/instantlatex-issue-20-e2e-${Date.now()}`,
+            userDataDir: profileDirectory,
             args: ['--no-first-run', '--disable-extensions']
         });
 
@@ -229,11 +235,44 @@ async function run() {
         assert.ok(state.url.startsWith(`http://127.0.0.1:${port}/`));
         console.log('same-origin embed: host page fragment still shareable');
         await page.close();
+    } catch (error) {
+        testError = error;
     } finally {
-        if (browser) {
-            await browser.close();
+        try {
+            if (browser) {
+                await browser.close();
+            }
+        } catch (error) {
+            cleanupError = error;
         }
-        await new Promise(resolve => server.close(resolve));
+
+        try {
+            fs.rmSync(profileDirectory, { recursive: true, force: true });
+            assert.equal(
+                fs.existsSync(profileDirectory),
+                false,
+                `browser profile should be removed after the test: ${profileDirectory}`
+            );
+        } catch (error) {
+            cleanupError ||= error;
+        }
+
+        if (server) {
+            try {
+                await new Promise((resolve, reject) => {
+                    server.close(error => error ? reject(error) : resolve());
+                });
+            } catch (error) {
+                cleanupError ||= error;
+            }
+        }
+    }
+
+    if (testError) {
+        throw testError;
+    }
+    if (cleanupError) {
+        throw cleanupError;
     }
 }
 


### PR DESCRIPTION
## Summary

- Document the shared Fleet host commands, including `npm test -- --maxWorkers=2`.
- Give each browser runner a unique `/tmp` Chrome profile and remove exactly that profile after Chrome closes.
- Preserve the original test failure while still closing the profile and HTTP server.

## Validation

- `npm test -- --maxWorkers=2`
- `npm run test:e2e`
- `npm run test:e2e:embed`
- Forced launch failure with `CHROME_PATH=/dev/null` for both browser runners

Fixes #21