### PR TITLE
fix: strip enclosing math delimiters from TeX expressions (#29)

### DIFF
--- a/public_html/main.js
+++ b/public_html/main.js
@@ -1,5 +1,103 @@
+function isEscaped(str, index) {
+    let backslashCount = 0;
+    for (let i = index - 1; i >= 0 && str[i] === '\\'; i--) {
+        backslashCount++;
+    }
+    return (backslashCount % 2) === 1;
+}
+
+function hasUnescapedDollar(str) {
+    for (let i = 0; i < str.length; i++) {
+        if (str[i] === '$' && !isEscaped(str, i)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function hasUnescapedDoubleDollar(str) {
+    for (let i = 0; i < str.length - 1; i++) {
+        if (str[i] === '$' && str[i + 1] === '$' && !isEscaped(str, i)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function hasUnescapedLatexCloser(str, closerChar) {
+    for (let i = 0; i < str.length - 1; i++) {
+        if (str[i] === '\\' && str[i + 1] === closerChar && !isEscaped(str, i)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function stripDelimiters(TeX) {
+    const trimmed = TeX.trim();
+
+    // LaTeX display delimiters: \[math\]
+    if (trimmed.startsWith('\\[') && trimmed.endsWith('\\]') && trimmed.length >= 4) {
+        if (!isEscaped(trimmed, trimmed.length - 2)) {
+            const inner = trimmed.slice(2, -2);
+            if (!hasUnescapedLatexCloser(inner, ']')) {
+                return inner.trim();
+            }
+        }
+    }
+
+    // LaTeX inline delimiters: \(math\)
+    if (trimmed.startsWith('\\(') && trimmed.endsWith('\\)') && trimmed.length >= 4) {
+        if (!isEscaped(trimmed, trimmed.length - 2)) {
+            const inner = trimmed.slice(2, -2);
+            if (!hasUnescapedLatexCloser(inner, ')')) {
+                return inner.trim();
+            }
+        }
+    }
+
+    // Display dollar delimiters: $$math$$
+    if (trimmed === '$$') {
+        return '';
+    }
+    if (trimmed.startsWith('$$') && trimmed.endsWith('$$') && trimmed.length >= 4) {
+        if (!isEscaped(trimmed, trimmed.length - 2)) {
+            const inner = trimmed.slice(2, -2);
+            if (!hasUnescapedDoubleDollar(inner)) {
+                return inner.trim();
+            }
+        }
+    }
+
+    // Inline dollar delimiters: $math$
+    if (
+        trimmed.startsWith('$') &&
+        !trimmed.startsWith('$$') &&
+        trimmed.endsWith('$') &&
+        !trimmed.endsWith('$$') &&
+        trimmed.length >= 2
+    ) {
+        if (!isEscaped(trimmed, trimmed.length - 1)) {
+            const inner = trimmed.slice(1, -1);
+            if (!hasUnescapedDollar(inner)) {
+                return inner.trim();
+            }
+        }
+    }
+
+    return TeX;
+}
+
 function formatMath(TeX) {
-    return (TeX && TeX !== "\\") ? TeX : "";
+    if (!TeX || typeof TeX !== 'string') {
+        return "";
+    }
+    if (TeX === "\\") {
+        return "";
+    }
+    const stripped = stripDelimiters(TeX);
+    const result = (stripped === "\\") ? "" : stripped;
+    return result;
 }
 
 if (typeof window !== 'undefined') {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -24,4 +24,88 @@ describe('formatMath', () => {
     it('returns empty string when TeX is just a backslash', () => {
         expect(formatMath('\\')).toBe('');
     });
+
+    describe('delimiter stripping (Issue #29)', () => {
+        const renderOpts = { throwOnError: true, displayMode: true };
+
+        it('strips enclosing inline dollar delimiters ($math$)', () => {
+            expect(formatMath('$x$')).toBe('x');
+            expect(formatMath('$x^2$')).toBe('x^2');
+            expect(formatMath('$\\frac{1}{2}$')).toBe('\\frac{1}{2}');
+            expect(() => katex.renderToString(formatMath('$x^2$'), renderOpts)).not.toThrow();
+            expect(() => katex.renderToString(formatMath('$\\frac{1}{2}$'), renderOpts)).not.toThrow();
+        });
+
+        it('strips enclosing display dollar delimiters ($$math$$)', () => {
+            expect(formatMath('$$x$$')).toBe('x');
+            expect(formatMath('$$x^2$$')).toBe('x^2');
+            expect(formatMath('$$\\frac{1}{2}$$')).toBe('\\frac{1}{2}');
+            expect(() => katex.renderToString(formatMath('$$x^2$$'), renderOpts)).not.toThrow();
+            expect(() => katex.renderToString(formatMath('$$\\frac{1}{2}$$'), renderOpts)).not.toThrow();
+        });
+
+        it('strips enclosing LaTeX inline delimiters (\\(math\\))', () => {
+            expect(formatMath('\\(x\\)')).toBe('x');
+            expect(formatMath('\\(x^2\\)')).toBe('x^2');
+            expect(formatMath('\\(\\frac{1}{2}\\)')).toBe('\\frac{1}{2}');
+            expect(() => katex.renderToString(formatMath('\\(x^2\\)'), renderOpts)).not.toThrow();
+            expect(() => katex.renderToString(formatMath('\\(\\frac{1}{2}\\)'), renderOpts)).not.toThrow();
+        });
+
+        it('strips enclosing LaTeX display delimiters (\\[math\\])', () => {
+            expect(formatMath('\\[x\\]')).toBe('x');
+            expect(formatMath('\\[x^2\\]')).toBe('x^2');
+            expect(formatMath('\\[\\frac{1}{2}\\]')).toBe('\\frac{1}{2}');
+            expect(() => katex.renderToString(formatMath('\\[x^2\\]'), renderOpts)).not.toThrow();
+            expect(() => katex.renderToString(formatMath('\\[\\frac{1}{2}\\]'), renderOpts)).not.toThrow();
+        });
+
+        it('handles surrounding whitespace around and inside enclosing delimiters cleanly', () => {
+            expect(formatMath('  $x$  ')).toBe('x');
+            expect(formatMath('  $\\frac{1}{2}$  ')).toBe('\\frac{1}{2}');
+            expect(formatMath('$\\frac{1}{2} $')).toBe('\\frac{1}{2}');
+            expect(formatMath('$ \\frac{1}{2} $')).toBe('\\frac{1}{2}');
+            expect(formatMath('  $$ \\frac{1}{2} $$  ')).toBe('\\frac{1}{2}');
+            expect(formatMath('  \\( \\frac{1}{2} \\)  ')).toBe('\\frac{1}{2}');
+            expect(formatMath('  \\[ \\frac{1}{2} \\]  ')).toBe('\\frac{1}{2}');
+            expect(() => katex.renderToString(formatMath('  $\\frac{1}{2}$  '), renderOpts)).not.toThrow();
+            expect(() => katex.renderToString(formatMath('$\\frac{1}{2} $'), renderOpts)).not.toThrow();
+        });
+
+        it('handles empty delimited math cleanly', () => {
+            expect(formatMath('$$')).toBe('');
+            expect(formatMath('$$$$')).toBe('');
+            expect(formatMath('$ $')).toBe('');
+            expect(formatMath('$$ $$')).toBe('');
+            expect(formatMath('\\(\\)')).toBe('');
+            expect(formatMath('\\( \\)')).toBe('');
+            expect(formatMath('\\[\\]')).toBe('');
+            expect(formatMath('\\[ \\]')).toBe('');
+        });
+
+        it('leaves unpaired or non-wrapping delimiters untouched without throwing', () => {
+            expect(formatMath('$')).toBe('$');
+            expect(formatMath('$x')).toBe('$x');
+            expect(formatMath('x$')).toBe('x$');
+            expect(formatMath('$$x$')).toBe('$$x$');
+            expect(formatMath('$x$$')).toBe('$x$$');
+            expect(formatMath('\\(x\\]')).toBe('\\(x\\]');
+            expect(formatMath('\\[x\\)')).toBe('\\[x\\)');
+            expect(formatMath('\\(x')).toBe('\\(x');
+            expect(formatMath('\\[x')).toBe('\\[x');
+            expect(formatMath('x\\)')).toBe('x\\)');
+            expect(formatMath('x\\]')).toBe('x\\]');
+            expect(formatMath('$5 and $10')).toBe('$5 and $10');
+            expect(formatMath('$x$ + $y$')).toBe('$x$ + $y$');
+            expect(formatMath('$$x$$ and $$y$$')).toBe('$$x$$ and $$y$$');
+            expect(formatMath('\\(x\\) and \\(y\\)')).toBe('\\(x\\) and \\(y\\)');
+            expect(formatMath('\\[x\\] and \\[y\\]')).toBe('\\[x\\] and \\[y\\]');
+        });
+
+        it('handles escaped delimiters inside math mode properly', () => {
+            expect(formatMath('$\\$5$')).toBe('\\$5');
+            expect(formatMath('$$\\text{Cost: } \\$100$$')).toBe('\\text{Cost: } \\$100');
+            expect(() => katex.renderToString(formatMath('$\\$5$'), renderOpts)).not.toThrow();
+        });
+    });
 });


### PR DESCRIPTION
Fixes #29

**Root cause:** Hypothesis 1 confirmed: `formatMath(TeX)` passed raw strings with enclosing math delimiters (`$...$`, `$$...$$`, `\(...\)`, `\[...\]`) directly to KaTeX. Because KaTeX evaluates expressions in math mode (`displayMode: true`), outer delimiters were treated as syntax errors or undefined control sequences, causing KaTeX to render red parse error elements.

**Fix:** Strip standard enclosing math delimiters (`$...$`, `$$...$$`, `\(...\)`, `\[...\]`) and clean surrounding/interior whitespace in `formatMath` while safely preserving delimiter-free math, escaped dollar signs, and unclosed or discrete expressions.

**Tests:**
- Comprehensive unit tests in `tests/main.test.js` covering all four delimiter pairs, interior/exterior whitespace, empty math, escaped inner dollars, and unmatched delimiters.
- All test suites pass: `npm test -- --maxWorkers=2`, `npm run test:e2e`, `npm run test:e2e:embed`, and `npm run test:e2e:wide`.
