### PR TITLE
fix: contain overflowing formulas so the editor stays on-screen

### DIFF
--- a/public_html/main.css
+++ b/public_html/main.css
@@ -92,6 +92,8 @@ body, html {
     display: flex;
     flex: 1;
     flex-direction: column;
+    min-width: 0;
+    min-height: 0;
     overflow: hidden; /* Prevent scrolling of the whole pane area, scroll individually */
 }
 
@@ -122,6 +124,8 @@ body, html {
     flex: 1;
     display: flex;
     flex-direction: column;
+    min-width: 0;
+    min-height: 0;
     overflow-y: auto;
 }
 
@@ -165,6 +169,8 @@ body, html {
     display: flex;
     align-items: center;
     font-size: 1.2rem;
+    position: relative;
+    flex-shrink: 0;
     overflow-x: auto;
     color: var(--text-color);
 }

--- a/tests/wide-formula.e2e.js
+++ b/tests/wide-formula.e2e.js
@@ -9,10 +9,12 @@ const publicDirectory = path.join(__dirname, '..', 'public_html');
 const katexDirectory = path.dirname(require.resolve('katex/dist/katex.min.js'));
 const wideFormula = String.raw`\text{START}` + ' + a'.repeat(80) + String.raw` + \text{END}`;
 const narrowFormula = String.raw`\frac{-b\pm\sqrt{b^2-4ac}}{2a}`;
+const tallFormula = `\\begin{align} ${Array.from({ length: 40 }, (_, i) => `x_{${i}} &= y_{${i}} + z_{${i}} \\\\`).join(' ')} \\end{align}`;
 const viewports = [
     { name: 'desktop split pane', width: 800, height: 600 },
     { name: 'mobile', width: 375, height: 667 }
 ];
+const overflowViewport = { name: 'desktop overflow', width: 1280, height: 800 };
 
 function findChrome() {
     const candidates = [
@@ -160,8 +162,89 @@ async function scrollToEnd(page) {
     });
 }
 
+async function measurePageOverflow(page, port, formula) {
+    await page.goto(`http://127.0.0.1:${port}/index.html#${encodeURIComponent(formula)}`, { waitUntil: 'load' });
+    await page.waitForSelector('#math-output .katex-display');
+    return page.evaluate(() => {
+        const editor = document.getElementById('maths-editor').getBoundingClientRect();
+        const header = document.querySelector('.ide-header').getBoundingClientRect();
+        const output = document.getElementById('math-output');
+        const pane = document.querySelector('.output-pane');
+        const math = output.querySelector('.katex-display');
+        return {
+            innerWidth: window.innerWidth,
+            innerHeight: window.innerHeight,
+            scrollWidth: document.documentElement.scrollWidth,
+            scrollHeight: document.documentElement.scrollHeight,
+            editorLeft: editor.left,
+            editorTop: editor.top,
+            editorRight: editor.right,
+            editorBottom: editor.bottom,
+            headerLeft: header.left,
+            headerTop: header.top,
+            headerRight: header.right,
+            headerBottom: header.bottom,
+            outputClientWidth: output.clientWidth,
+            outputScrollWidth: output.scrollWidth,
+            paneClientHeight: pane.clientHeight,
+            paneScrollHeight: pane.scrollHeight,
+            mathBottom: math.getBoundingClientRect().bottom
+        };
+    });
+}
+
+function editorOnScreen(metrics) {
+    return metrics.editorRight > 0 &&
+        metrics.editorLeft < metrics.innerWidth &&
+        metrics.editorBottom > 0 &&
+        metrics.editorTop < metrics.innerHeight;
+}
+
+function headerOnScreen(metrics) {
+    return metrics.headerRight > 0 &&
+        metrics.headerLeft < metrics.innerWidth &&
+        metrics.headerBottom > 0 &&
+        metrics.headerTop < metrics.innerHeight;
+}
+
+async function scrollWindowToEnd(page) {
+    return page.evaluate(() => {
+        window.scrollTo(document.documentElement.scrollWidth, document.documentElement.scrollHeight);
+        const editor = document.getElementById('maths-editor').getBoundingClientRect();
+        const header = document.querySelector('.ide-header').getBoundingClientRect();
+        return {
+            innerWidth: window.innerWidth,
+            innerHeight: window.innerHeight,
+            scrollX: window.scrollX,
+            scrollY: window.scrollY,
+            editorLeft: editor.left,
+            editorTop: editor.top,
+            editorRight: editor.right,
+            editorBottom: editor.bottom,
+            headerLeft: header.left,
+            headerTop: header.top,
+            headerRight: header.right,
+            headerBottom: header.bottom
+        };
+    });
+}
+
+async function scrollOutputPaneToEnd(page) {
+    return page.evaluate(() => {
+        const pane = document.querySelector('.output-pane');
+        pane.scrollTop = pane.scrollHeight;
+        const math = document.querySelector('#math-output .katex-display').getBoundingClientRect();
+        const paneRect = pane.getBoundingClientRect();
+        return {
+            paneScrollTop: pane.scrollTop,
+            mathBottom: math.bottom,
+            paneBottom: paneRect.bottom
+        };
+    });
+}
+
 async function run() {
-    const profileDirectory = fs.mkdtempSync(path.join('/tmp', 'instantlatex-issue-26-e2e-'));
+    const profileDirectory = fs.mkdtempSync(path.join('/tmp', 'instantlatex-issue-31-e2e-'));
     let server;
     let browser;
     let testError;
@@ -206,6 +289,77 @@ async function run() {
             console.log(`${viewport.name}: wide formula start visible and end reachable; narrow formula centred`);
             await page.close();
         }
+
+        const overflowPage = await browser.newPage();
+        await overflowPage.setViewport({ width: overflowViewport.width, height: overflowViewport.height });
+        await interceptThirdParty(overflowPage, port);
+
+        const wideOverflow = await measurePageOverflow(overflowPage, port, wideFormula);
+        assert.ok(
+            wideOverflow.outputScrollWidth > wideOverflow.outputClientWidth,
+            `${overflowViewport.name}: wide formula should overflow the preview (${JSON.stringify(wideOverflow)})`
+        );
+        assert.ok(
+            wideOverflow.scrollWidth <= wideOverflow.innerWidth,
+            `${overflowViewport.name}: wide formula must not expand the page width (${JSON.stringify(wideOverflow)})`
+        );
+        assert.ok(
+            editorOnScreen(wideOverflow) && headerOnScreen(wideOverflow),
+            `${overflowViewport.name}: editor and header must stay on-screen for a wide formula (${JSON.stringify(wideOverflow)})`
+        );
+        const afterWideWindowScroll = await scrollWindowToEnd(overflowPage);
+        assert.equal(afterWideWindowScroll.scrollX, 0, `${overflowViewport.name}: page must not scroll horizontally (${JSON.stringify(afterWideWindowScroll)})`);
+        assert.ok(
+            editorOnScreen(afterWideWindowScroll) && headerOnScreen(afterWideWindowScroll),
+            `${overflowViewport.name}: scrolling a wide formula must not move the editor off-screen (${JSON.stringify(afterWideWindowScroll)})`
+        );
+
+        const tallOverflow = await measurePageOverflow(overflowPage, port, tallFormula);
+        assert.ok(
+            tallOverflow.mathBottom > tallOverflow.innerHeight,
+            `${overflowViewport.name}: tall formula should extend past the viewport (${JSON.stringify(tallOverflow)})`
+        );
+        assert.ok(
+            tallOverflow.scrollHeight <= tallOverflow.innerHeight,
+            `${overflowViewport.name}: tall formula must not expand the page height (${JSON.stringify(tallOverflow)})`
+        );
+        assert.ok(
+            tallOverflow.paneScrollHeight > tallOverflow.paneClientHeight,
+            `${overflowViewport.name}: output pane must own vertical overflow (${JSON.stringify(tallOverflow)})`
+        );
+        assert.ok(
+            editorOnScreen(tallOverflow) && headerOnScreen(tallOverflow),
+            `${overflowViewport.name}: editor and header must stay on-screen for a tall formula (${JSON.stringify(tallOverflow)})`
+        );
+        const afterPaneScroll = await scrollOutputPaneToEnd(overflowPage);
+        assert.ok(
+            afterPaneScroll.paneScrollTop > 0,
+            `${overflowViewport.name}: output pane must scroll to reveal tall formula rows (${JSON.stringify(afterPaneScroll)})`
+        );
+        assert.ok(
+            afterPaneScroll.mathBottom <= afterPaneScroll.paneBottom + 1,
+            `${overflowViewport.name}: last tall formula rows must be reachable inside the output pane (${JSON.stringify(afterPaneScroll)})`
+        );
+        const afterTallWindowScroll = await scrollWindowToEnd(overflowPage);
+        assert.equal(afterTallWindowScroll.scrollY, 0, `${overflowViewport.name}: page must not scroll vertically (${JSON.stringify(afterTallWindowScroll)})`);
+        assert.ok(
+            editorOnScreen(afterTallWindowScroll) && headerOnScreen(afterTallWindowScroll),
+            `${overflowViewport.name}: scrolling a tall formula must not move the editor off-screen (${JSON.stringify(afterTallWindowScroll)})`
+        );
+
+        const narrowOverflow = await measurePageOverflow(overflowPage, port, narrowFormula);
+        assert.ok(
+            editorOnScreen(narrowOverflow) && headerOnScreen(narrowOverflow),
+            `${overflowViewport.name}: default formula must keep the editor on-screen (${JSON.stringify(narrowOverflow)})`
+        );
+        assert.ok(
+            narrowOverflow.scrollWidth <= narrowOverflow.innerWidth &&
+                narrowOverflow.scrollHeight <= narrowOverflow.innerHeight,
+            `${overflowViewport.name}: default formula must not expand the page (${JSON.stringify(narrowOverflow)})`
+        );
+
+        console.log(`${overflowViewport.name}: page stays fixed for wide and tall formulas; editor remains on-screen`);
+        await overflowPage.close();
     } catch (error) {
         testError = error;
     } finally {


### PR DESCRIPTION
## Summary

- Keep KaTeX MathML inside `#math-output` so wide formulas cannot expand the document.
- Let flex panes shrink (`min-width: 0; min-height: 0`) and give tall overflow to the output pane.
- Extend the wide-formula browser suite to assert page scroll stays within the viewport and the editor remains on-screen.

## Root cause

KaTeX's `.katex-mathml` is `position: absolute` without a positioned ancestor, so it used the initial containing block and stretched `document.documentElement.scrollWidth` (~1100px). Tall `align` environments grew `#math-output` in a way that did not create an inner pane scrollbar, so the only way to read the last rows was window scrolling, which moved the editor off-screen.

## Validation

- npm test -- --maxWorkers=2
- npm run test:e2e
- npm run test:e2e:layout
- npm run test:e2e:wide
- npm run test:e2e:embed

Fixes #31